### PR TITLE
Add pre-commit-config and CONTRIBUTING.md

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-ast
+      - id: check-json
+        types: [text]
+        files: \.(json|ipynb)$
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.6
+    hooks:
+      - id: ruff
+        name: ruff isort
+        args: [--select, I, --fix]
+        types_or: [python, jupyter]
+      - id: ruff-format
+        types_or: [python, jupyter]
+  - repo: https://github.com/rbubley/mirrors-prettier # Update mirror as official mirror is deprecated
+    rev: v3.4.2
+    hooks:
+      - id: prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,7 @@ repos:
     rev: v3.4.2
     hooks:
       - id: prettier
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.8.1
+    hooks:
+      - id: nbstripout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# General dev setup
+
+This monorepo uses pre-commit hooks to run automated tooling - ensuring code
+quality and to prevent syntactically broken code from entering the codebase.
+To set up the pre-commit hooks:
+
+- Install pre-commit
+  - Projects will likely have pre-commit as a dev dependency anyway, so you may not have to separately install it.
+  - Separate installation can be done via [brew](https://formulae.brew.sh/formula/pre-commit), via [conda](https://anaconda.org/conda-forge/pre_commit), or via [pip](https://pypi.org/project/pre-commit/)
+- Run `pre-commit install`
+  - This will mean that pre-commit runs on every commit that you make
+
+See pre-commmit's usage section for info on manually running the rool. See the
+`.pre-commit-config.yaml` file for info on which hooks are configured.
+
+See the `CONTRIBUTING.md` file in project folders for project specific dev setup instructions.


### PR DESCRIPTION
I think we should adopt pre-commit to handle code quality here on a repo level (and also on a project level if you want specific hooks for that - https://github.com/pre-commit/pre-commit/issues/466#issuecomment-274282684 ).

I think we should also add [pre-commit CI](https://pre-commit.ci/) to enforce this is CI.

This would make it easier to collaborate as a team with a unified coding style.